### PR TITLE
Typo in variable name: parser —> self.parser

### DIFF
--- a/libdeda/pattern_handler.py
+++ b/libdeda/pattern_handler.py
@@ -431,7 +431,7 @@ class TDM(object):
             else cropped
         
     def __getattr__(self, name):
-        return getattr(parser,name)(self.m)
+        return getattr(self.parser,name)(self.m)
         
     def decode(self):
         return self.parser.decode(self.cropped)


### PR DESCRIPTION
__parser__ is an _undefined name_ in this context but __self.parser__ is used in the methods above and below.

Is the trailing __(self.m)__ required/useful??