### PR TITLE
self.m is never set in this class so removing

### DIFF
--- a/libdeda/pattern_handler.py
+++ b/libdeda/pattern_handler.py
@@ -425,13 +425,11 @@ class TDM(object):
         self.atY = atY
         self.parser = patterns[pattern]
         self.trans = trans
-        self.aligned = self.parser.applyTransformation(m,self.trans) if \
-            aligned is None else aligned
-        self.cropped = self.parser.crop(self.aligned) if cropped is None \
-            else cropped
+        self.aligned = aligned or self.parser.applyTransformation(m,self.trans)
+        self.cropped = cropped or self.parser.crop(self.aligned)
         
     def __getattr__(self, name):
-        return getattr(self.parser,name)(self.m)
+        return getattr(self.parser,name)
         
     def decode(self):
         return self.parser.decode(self.cropped)


### PR DESCRIPTION
__self.m__ would raise NameError at runtime because it is never set in this class.

Also, simplify the logic with __or__.