### PR TITLE
Revert "self.m is never set in this class so removing"

### DIFF
--- a/libdeda/pattern_handler.py
+++ b/libdeda/pattern_handler.py
@@ -425,11 +425,13 @@ class TDM(object):
         self.atY = atY
         self.parser = patterns[pattern]
         self.trans = trans
-        self.aligned = aligned or self.parser.applyTransformation(m,self.trans)
-        self.cropped = cropped or self.parser.crop(self.aligned)
+        self.aligned = self.parser.applyTransformation(m,self.trans) if \
+            aligned is None else aligned
+        self.cropped = self.parser.crop(self.aligned) if cropped is None \
+            else cropped
         
     def __getattr__(self, name):
-        return getattr(self.parser,name)
+        return getattr(self.parser,name)(self.m)
         
     def decode(self):
         return self.parser.decode(self.cropped)


### PR DESCRIPTION
Reverts dfd-tud/deda#3;
variables "aligned" and "cropped" may be numpy arrays, which would map the operators (or, and) to custom functions. Using "is None" to use native operators.