### PR TITLE
change beginning sentence in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DEDA - tracking Dots Extraction, Decoding and Anonymisation toolkit
 =================================================================
 
-Document Colour Tracking Dots or simply yellow dots are small systematic dots in yellow color which encode information about the printer and/or the printout itself. This process is integrated in almost every commercial colour laser printer. This means that almost every printout contains coded information about the source device, such as the serial number. 
+Document Colour Tracking Dots, or yellow dots, are small systematic dots which encode information about the printer and/or the printout itself. This process is integrated in almost every commercial colour laser printer. This means that almost every printout contains coded information about the source device, such as the serial number. 
 
 On the one hand, this tool gives the possibility to read out and decode these forensic features and on the other hand, it allows anonymisation to prevent arbitrary tracking.
 


### PR DESCRIPTION
- "or yellow dots" was changed to an inserted phrase to make it more obvious that Document Colour Tracking Dots are referred to as "yellow dots" as well.

- "in yellow color" was removed to reduce redundancy. It is implied that the dots are yellow from the name "yellow dots". 