### PR TITLE
Fix for #29

### DIFF
--- a/libdeda/privacy.py
+++ b/libdeda/privacy.py
@@ -142,7 +142,7 @@ class AnonmaskCreator(object):
         im = self._selectColour(colour)
         contours = np.array(cv2.findContours(
             im,cv2.RETR_EXTERNAL,cv2.CHAIN_APPROX_SIMPLE)[-2],
-            dtype=np.object)
+            dtype=object)
         area = np.array([(np.max(contour[:,0])-np.min(contour[:,0]))
                 *(np.max(contour[:,1])-np.min(contour[:,1]))
             for e in contours for contour in [e[:,0]]])/self.dpi**2


### PR DESCRIPTION
Fix for #29 
```
❯ deda_anonmask_create -r Image.png
/root/.local/lib/python3.11/site-packages/libdeda/privacy.py:143: FutureWarning: In the future `np.object` will be defined as the corresponding NumPy scalar.
  dtype=np.object)
Traceback (most recent call last):
  File "/root/.local/bin/deda_anonmask_create", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/root/.local/lib/python3.11/site-packages/deda_bin/deda_anonmask_create.py", line 50, in <lambda>
    main = lambda:Main()()
                  ^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/deda_bin/deda_anonmask_create.py", line 43, in __call__
    mask = calibrationScan2Anonmask(fp.read(),self.args.copy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/libdeda/privacy.py", line 273, in calibrationScan2Anonmask
    return AnonmaskCreator(imbin,verbose)(copy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/libdeda/privacy.py", line 104, in __call__
    self.restoreOrientation()
  File "/root/.local/lib/python3.11/site-packages/libdeda/privacy.py", line 150, in restoreOrientation
    contours = self._findContours(CYAN)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/libdeda/privacy.py", line 143, in _findContours
    dtype=np.object)
          ^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'object'.
`np.object` was a deprecated alias for the builtin `object`. To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'object_'?    
```